### PR TITLE
Console/Environment Variable Output

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 0
-:minor: 5
-:patch: 1
+:minor: 6
+:patch: 0
 :special: ''
 :metadata: ''

--- a/bin/aws_session_token
+++ b/bin/aws_session_token
@@ -1,6 +1,24 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+#
+# AWS Session Token Gem - Tool to wrap AWS API to create and store Session tokens
+# so that other commands/tools (e.g. Terraform) can function as necessary.
+#
+# Copyright 2018 Bryan Stopp <bryan.stopp@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 $LOAD_PATH.unshift("#{__dir__}/../lib")
 
 require 'aws_session_token'

--- a/lib/aws_session_token.rb
+++ b/lib/aws_session_token.rb
@@ -25,5 +25,6 @@ require 'semver'
 require 'highline'
 
 require_relative 'aws_session_token/cli'
+require_relative 'aws_session_token/console'
 require_relative 'aws_session_token/credentials_file'
 require_relative 'aws_session_token/options'

--- a/lib/aws_session_token/cli.rb
+++ b/lib/aws_session_token/cli.rb
@@ -28,6 +28,7 @@ module AwsSessionToken
     def initialize
       @options = Options.new
       @creds_file = CredentialsFile.new
+      @console = Console.new
     end
 
     def run
@@ -37,7 +38,8 @@ module AwsSessionToken
       mfa = mfa_device
       token = @options.token || token_prompt
       creds = session_token(mfa, token)
-      @creds_file.write(@options.credentials_file, @options.session_profile, creds)
+      @creds_file.write(@options.credentials_file, @options.session_profile, creds) if @options.session_profile
+      @console.write(creds) if @options.console
     end
 
     def validate_creds_file

--- a/lib/aws_session_token/console.rb
+++ b/lib/aws_session_token/console.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module AwsSessionToken
+
+  # Helper class for outputting creds to console in export variable format.
+  class Console
+
+    def write(credentials)
+      $stdout.puts "export AWS_ACCESS_KEY_ID=#{credentials.access_key_id}"
+      $stdout.puts "export AWS_SECRET_ACCESS_KEY=#{credentials.secret_access_key}"
+      $stdout.puts "export AWS_SESSION_TOKEN=#{credentials.session_token}"
+    end
+  end
+end

--- a/lib/aws_session_token/console.rb
+++ b/lib/aws_session_token/console.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+#
+# AWS Session Token Gem - Tool to wrap AWS API to create and store
+# Session tokens so that other commands/tools (e.g. Terraform) can function as
+# necessary.
+#
+#
+# Copyright 2018 Bryan Stopp <bryan.stopp@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 module AwsSessionToken
 
   # Helper class for outputting creds to console in export variable format.

--- a/spec/aws_session_token/cli_spec.rb
+++ b/spec/aws_session_token/cli_spec.rb
@@ -50,6 +50,10 @@ describe AwsSessionToken::CLI do
   let(:mfa_token) { '123456' }
 
   describe 'run' do
+    before do
+      ARGV.clear
+      ARGV << '-s'
+    end
     it 'should work' do
       expect(cli).to receive(:set_aws_creds)
       expect(cli).to receive(:mfa_device).and_return(mfa_arn)


### PR DESCRIPTION
Allow for user to specify outputting session credentials as environment variables.